### PR TITLE
Install submodules in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import os
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name="bridgestyle",
@@ -10,6 +10,6 @@ setup(
     license="MIT",
     keywords="GeoCat",
     url="",
-    packages=["bridgestyle"],
+    packages=find_packages(),
     entry_points={"console_scripts": ["style2style=bridgestyle.style2style:main"]},
 )


### PR DESCRIPTION
For me this edit was necessary in order to use bridgestyle in my Python installation, otherwise I get error messages like this:
```
from bridgestyle import arcgis, sld
ImportError: cannot import name 'arcgis' from 'bridgestyle' (/usr/local/lib/python3.8/dist-packages/bridgestyle-0.1-py3.8.egg/bridgestyle/__init__.py)
```