### PR TITLE
Add support for symbol transparency

### DIFF
--- a/bridgestyle/arcgis/togeostyler.py
+++ b/bridgestyle/arcgis/togeostyler.py
@@ -326,8 +326,14 @@ def processSymbolLayer(layer, symboltype, options):
             color = processColor(layer["symbol"]["symbolLayers"][0].get("color"))
         except KeyError:
             color = "#000000"
+        try:
+            opacity = layer["symbol"]["symbolLayers"][0].get("color").get("values")[3]/100
+        except (KeyError, IndexError):
+            opacity = 1.0
         return {
             "opacity": 1.0,
+            "fillOpacity": opacity,
+            "strokeOpacity": opacity,
             "rotate": rotate,
             "kind": "Mark",
             "color": color,


### PR DESCRIPTION
[GEO-4802](https://jira.camptocamp.com/browse/GEO-4802)
Test data: 
 - va_lsparznr_01.lyrx (transparent)
- naturobjekte-innerhalb-der-bauzone/input.lyrx (not transparent)