### PR TITLE
Fix ArcGIS stroke angle (slash-backslash)

### DIFF
--- a/bridgestyle/arcgis/togeostyler.py
+++ b/bridgestyle/arcgis/togeostyler.py
@@ -301,9 +301,9 @@ def _hatchMarkerForAngle(angle):
     quadrant = math.floor(((angle + 22.5) % 180) / 45.0)
     return [
         "shape://horline",
-        "shape://backslash",
-        "shape://vertline",
         "shape://slash",
+        "shape://vertline",
+        "shape://backslash",
     ][quadrant]
 
 


### PR DESCRIPTION
For GEO-6022

Fro style like:
```
                      {
                        "type" : "CIMHatchFill",
                        "enable" : true,
                        "colorLocked" : true,
                        "lineSymbol" : {...},
                        "rotation" : 45,
                        "separation" : 4
                      },
```

A slash is expected. And a backslash was given. (same error with `rotation: -45`)
