### PR TITLE
add support for nbBreakLine

### DIFF
--- a/bridgestyle/arcgis/expressions.py
+++ b/bridgestyle/arcgis/expressions.py
@@ -1,4 +1,7 @@
 # For now, this is limited to compound labels using the python, VB or Arcade syntax
+from bridgestyle.customgeostylerproperties import WellKnownText
+
+
 def convertExpression(expression, engine, tolowercase):
     if engine == "Arcade":
         expression = expression.replace("$feature.","")
@@ -16,7 +19,8 @@ def convertExpression(expression, engine, tolowercase):
                     ["PropertyName", token.replace("[", "").replace("]", "").strip()]
                 )
             else:
-                addends.append(token.replace('"', ""))
+                literal = token.replace('"', "")
+                addends.append(replaceSpecialLiteral(literal))
             allOps = addends[0]
             for attr in addends[1:]:
                 allOps = ["Concatenate", attr, allOps]
@@ -24,6 +28,12 @@ def convertExpression(expression, engine, tolowercase):
     else:
         expression = ["PropertyName", expression.replace("[", "").replace("]", "")]
     return expression
+
+
+def replaceSpecialLiteral(literal):
+    if literal == "vbnewline":
+        return WellKnownText.NEW_LINE
+    return literal
 
 
 def stringToParameter(s, tolowercase):

--- a/bridgestyle/customgeostylerproperties.py
+++ b/bridgestyle/customgeostylerproperties.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+# A less custom literal would be great, see: https://github.com/geostyler/geostyler-style/issues/548
+class WellKnownText(Enum):
+    NEW_LINE = '[newline]'

--- a/bridgestyle/sld/fromgeostyler.py
+++ b/bridgestyle/sld/fromgeostyler.py
@@ -3,7 +3,9 @@ from xml.dom import minidom
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element, SubElement
 
+from.parsecdata import _serialize_xml
 from .transformations import processTransformation
+from bridgestyle.customgeostylerproperties import WellKnownText
 from bridgestyle.version import __version__
 
 _warnings = []
@@ -567,6 +569,23 @@ def handleFunction(exp):
 
 
 def handleLiteral(v):
+    specialLiteralElem = handleSpecialLiteral(v)
+    if (specialLiteralElem is not None):
+        return specialLiteralElem
     elem = Element("ogc:Literal")
     elem.text = str(v)
     return elem
+
+
+def handleSpecialLiteral(v):
+    if v == WellKnownText.NEW_LINE:
+        elem = Element("ogc:Literal")
+        elem.append(createCDATA("\n"))
+        return elem
+    return None
+
+
+def createCDATA(text=None):
+    element = Element("![CDATA[")
+    element.text = text
+    return element

--- a/bridgestyle/sld/parsecdata.py
+++ b/bridgestyle/sld/parsecdata.py
@@ -1,0 +1,16 @@
+# Hack to add cdata with xml.etree
+from xml.etree import ElementTree
+
+ElementTree._original_serialize_xml = ElementTree._serialize_xml
+
+
+def _serialize_xml(write, elem, qnames, namespaces,short_empty_elements, **kwargs):
+    if elem.tag == '![CDATA[':
+        write("<{}{}]]>".format(elem.tag, elem.text))
+        if elem.tail:
+            write(ElementTree._escape_cdata(elem.tail))
+    else:
+        return ElementTree._original_serialize_xml(write, elem, qnames, namespaces,short_empty_elements, **kwargs)
+
+
+ElementTree._serialize_xml = ElementTree._serialize['xml'] = _serialize_xml


### PR DESCRIPTION
For GEO-6017

Hacky support for carriage return. Hacky because:
 - There is no such "symbol" in Geostyler, I've added a custom property in this project (`WellKnownText.NEW_LINE`)
 - xml.etree can't add CDATA section (lxml would do that, but that's probably a bigger change)