### PR TITLE
Use only "separation" as base size for polygon fill.

### DIFF
--- a/bridgestyle/arcgis/togeostyler.py
+++ b/bridgestyle/arcgis/togeostyler.py
@@ -520,10 +520,9 @@ def processSymbolLayer(layer, symboltype, options):
 
     elif layer["type"] == "CIMHatchFill":
         rotation = layer.get("rotation", 0)
-        separation = layer.get("separation", 2)
+        size = layer.get("separation", 2)
         symbolLayers = layer["lineSymbol"]["symbolLayers"]
         color, width = _extractStroke(symbolLayers)
-        size = separation + width
         wellKnowName = _hatchMarkerForAngle(rotation)
         fill = {
             "kind": "Fill",


### PR DESCRIPTION
Before that was (stroke-)width + separation. But that's not correct and not possible. In ArgCIS, if the stroke-width is bigger than the separation, then you don't see any separation anymore between lines.