### PR TITLE
Better 'OR' clause (more than 2 items)

### DIFF
--- a/bridgestyle/arcgis/togeostyler.py
+++ b/bridgestyle/arcgis/togeostyler.py
@@ -213,8 +213,10 @@ def processUniqueValueGroup(fields, group, options):
     def _and(a, b):
         return ["And", a, b]
 
-    def _or(a, b):
-        return ["Or", a, b]
+    def _or(conditions):
+        orConditions = conditions
+        orConditions.insert(0, 'Or')
+        return orConditions
 
     def _equal(name, val):
         if val == "<Null>":
@@ -241,9 +243,7 @@ def processUniqueValueGroup(fields, group, options):
                     condition = _and(condition, _equal(fieldName, fieldValue))
                 conditions.append(condition)
         if conditions:
-            ruleFilter = conditions[0]
-            for condition in conditions[1:]:
-                ruleFilter = _or(ruleFilter, condition)
+            ruleFilter = _or(conditions)
 
             rule["filter"] = ruleFilter
             rule["symbolizers"] = processSymbolReference(clazz["symbol"], options)


### PR DESCRIPTION
Or clause with more than two elements was (valide but ugly):

```
          <ogc:Filter>
            <ogc:Or>
              <ogc:Or>
                <ogc:Or>
                  <ogc:Or>
                    <ogc:Or>
                      <ogc:Or>
                        <ogc:Or>
                          <ogc:PropertyIsEqualTo>
                            <ogc:PropertyName>type_code</ogc:PropertyName>
                            <ogc:Literal>8111</ogc:Literal>
                          </ogc:PropertyIsEqualTo>
                          <ogc:PropertyIsEqualTo>
                            <ogc:PropertyName>type_code</ogc:PropertyName>
                            <ogc:Literal>8113</ogc:Literal>
                          </ogc:PropertyIsEqualTo>
                        </ogc:Or>
                        <ogc:PropertyIsEqualTo>
                          <ogc:PropertyName>type_code</ogc:PropertyName>
                          <ogc:Literal>8114</ogc:Literal>
                        </ogc:PropertyIsEqualTo>
                      </ogc:Or>
                      <ogc:PropertyIsEqualTo>
                        <ogc:PropertyName>type_code</ogc:PropertyName>
                        <ogc:Literal>8119</ogc:Literal>
                      </ogc:PropertyIsEqualTo>
                    </ogc:Or>
                    <ogc:PropertyIsEqualTo>
                      <ogc:PropertyName>type_code</ogc:PropertyName>
                      <ogc:Literal>8121</ogc:Literal>
                    </ogc:PropertyIsEqualTo>
                  </ogc:Or>
                  <ogc:PropertyIsEqualTo>
                    <ogc:PropertyName>type_code</ogc:PropertyName>
                    <ogc:Literal>8123</ogc:Literal>
                  </ogc:PropertyIsEqualTo>
                </ogc:Or>
                <ogc:PropertyIsEqualTo>
                  <ogc:PropertyName>type_code</ogc:PropertyName>
                  <ogc:Literal>8124</ogc:Literal>
                </ogc:PropertyIsEqualTo>
              </ogc:Or>
              <ogc:PropertyIsEqualTo>
                <ogc:PropertyName>type_code</ogc:PropertyName>
                <ogc:Literal>8129</ogc:Literal>
              </ogc:PropertyIsEqualTo>
            </ogc:Or>
          </ogc:Filter>
```

Now its:

```
          <ogc:Filter>
            <ogc:Or>
              <ogc:PropertyIsEqualTo>
                <ogc:PropertyName>type_code</ogc:PropertyName>
                <ogc:Literal>8111</ogc:Literal>
              </ogc:PropertyIsEqualTo>
              <ogc:PropertyIsEqualTo>
                <ogc:PropertyName>type_code</ogc:PropertyName>
                <ogc:Literal>8113</ogc:Literal>
              </ogc:PropertyIsEqualTo>
              <ogc:PropertyIsEqualTo>
                <ogc:PropertyName>type_code</ogc:PropertyName>
                <ogc:Literal>8114</ogc:Literal>
              </ogc:PropertyIsEqualTo>
              <ogc:PropertyIsEqualTo>
                <ogc:PropertyName>type_code</ogc:PropertyName>
                <ogc:Literal>8119</ogc:Literal>
              </ogc:PropertyIsEqualTo>
              <ogc:PropertyIsEqualTo>
                <ogc:PropertyName>type_code</ogc:PropertyName>
                <ogc:Literal>8121</ogc:Literal>
              </ogc:PropertyIsEqualTo>
              <ogc:PropertyIsEqualTo>
                <ogc:PropertyName>type_code</ogc:PropertyName>
                <ogc:Literal>8123</ogc:Literal>
              </ogc:PropertyIsEqualTo>
              <ogc:PropertyIsEqualTo>
                <ogc:PropertyName>type_code</ogc:PropertyName>
                <ogc:Literal>8124</ogc:Literal>
              </ogc:PropertyIsEqualTo>
              <ogc:PropertyIsEqualTo>
                <ogc:PropertyName>type_code</ogc:PropertyName>
                <ogc:Literal>8129</ogc:Literal>
              </ogc:PropertyIsEqualTo>
            </ogc:Or>
          </ogc:Filter>
```