### PR TITLE
Workaround to support separation between slash-fill lines

### DIFF
--- a/bridgestyle/arcgis/togeostyler.py
+++ b/bridgestyle/arcgis/togeostyler.py
@@ -623,8 +623,10 @@ def processSymbolLayer(layer, symboltype, options):
             else:
                 # In case of slash pattern, the pattern is the hypotenuse, we want the X (or Y) value for the size.
                 neededSize = math.cos(math.radians(45)) * neededSize
-                # The trick with the margin to keep the original size is not possible.
-                _warnings.append('Unable to keep the original size of CIMHatchFill with tilted symbol (slash).')
+                # The trick with the margin to keep the original size is not possible, add a workaround:
+                # Multiply the needed size regarding the separation (size) and the pattern size (neededSize)
+                neededSize = neededSize * (math.ceil((size * 2) / neededSize)) or neededSize
+                _warnings.append('Unable to keep the original size of CIMHatchFill with tilted symbol (slash, rotation, etc).')
             fill["graphicFill"][0]["size"] = neededSize
         return fill
 


### PR DESCRIPTION
GEO-6208 - tilted/slash part

Long description from the ticket:

Let's take your last example (with green lines):

 - I suppose the dash pattern is "3 2" in points.
 - In pixels (we need to round), it's "4 3"
 - To display the pattern entirely, GeoServer needs a size of 4+3 = 7px. So a square of 7x7px.
 - But 7 is for horizontal or vertical length. With a 45° slope, 7 is the hypotenuse, the side will be then: cos(45) * 7 = 4.9px

 

Now with my tests I have seen that GeoServer is not so smart, and each pattern (here with sides of 4.9x4.9) is "a box". As the line touches each corner, I can't use negative margin, otherwise it covers the next box and crops it. (even with transparent background).

So the only separation I can imagine is a multiple (int) of the original size, meaning: 0, 1, 2, 3, etc times the original size, to move a "box" exactly over another "box" to have no visual cut on the dash pattern.

Without given separation, the visual separation is small with a small dash pattern (here 4.9px, with a line of 1.3px, looking ~like a 2px line)
But the separation is already big with a big dash pattern. "4, 3, 5, 2" (in px) would have a size of 13.4px (for the same line width, that makes visually a big separation).

 

Now with the given separation of 3pt => 4px an my calculation:
 - I double it arbitrary because the visual separation is not big enough, so 8px.
 - with the "4, 3" pattern: 8 / 4.9 = 1.63. With math.ceil(1.63) = x2.
 - With the "4, 3, 5, 2" pattern: 8 / 13.4 = 0.59. With math.ceil = x1.
 
So the size will be twice the original size with the first small pattern, and not touched with the second that has already a big separation.
 
 Same calculation with a separation of 7pt => 9px. I take the double => 18px
 - with the "4, 3" pattern: 18 / 4.9 = 3.87. With math.ceil(3.67) = x4.
 - With the "4, 3, 5, 2" pattern: 18 / 13.4 = 1.34. With math.ceil(1.34) = x2.
 
 x4 for the small pattern, x2 for the big one.

 

The arbitrary "separation * 2" is really discutable, but with your example, no multiplication make the visual  separation too small. Maybe "separation * 1.5" would be better.