### PR TITLE
Add support for CIMMarkerPlacementAtExtremities

### DIFF
--- a/bridgestyle/arcgis/constants.py
+++ b/bridgestyle/arcgis/constants.py
@@ -1,9 +1,18 @@
+from enum import Enum
+
+
 ESRI_SYMBOLS_FONT = "ESRI Default Marker"
 PT_TO_PX_FACTOR = 4/3
 POLYGON_FILL_RESIZE_FACTOR = 2/3
 OFFSET_FACTOR = 4/3
-MARKER_PLACEMENT_POSITION = ["startPoint", "endPoint"]
-MARKER_PLACEMENT_ANGLE = ["startAngle", "endAngle"]
+
+class MarkerPlacementPosition(Enum):
+    START = "startPoint"
+    END = "endPoint"
+
+class MarkerPlacementAngle(Enum):
+    START = "startAngle"
+    END = "endAngle"
 
 def pt_to_px(pt):
     return pt * PT_TO_PX_FACTOR


### PR DESCRIPTION
This is for oriented markers at the end of lines (typically arrow heads). We already supported the cases where one marker was either at the end or at the beginning of a line (CIMMarkerPlacementAtRatioPositions with position 0 or 1). In ArcGIS, there is additionally the case where one symbolizer specifies one marker at both ends of the line (CIMMarkerPlacementAtExtremities), so we need to created two symbolizers for this one.

GEO-6929