### PR TITLE
Fix WTK polygon handling for polygon marker fill

### DIFF
--- a/bridgestyle/arcgis/togeostyler.py
+++ b/bridgestyle/arcgis/togeostyler.py
@@ -401,16 +401,20 @@ def _processOrientedMarkerAtEndOfLine(layer, orientedMarker, options):
 def processMarkerPlacementInsidePolygon(symbolizer, markerPlacement):
     # In case of markers in a polygon fill, it seems ArcGIS does some undocumented resizing of the marker.
     # We use an empirical factor to account for this, which works in most cases (but not all)
+    if symbolizer.get("wellKnownName").startswith("wkt://POLYGON"):
+        resize_factor = 1
+    else:
+        resize_factor = POLYGON_FILL_RESIZE_FACTOR
     # Size is already in pixel.
     # Avoid null values and force them to 1 px
-    size = round(symbolizer.get("size", 0) * POLYGON_FILL_RESIZE_FACTOR) or 1
+    size = round(symbolizer.get("size", 0) * resize_factor) or 1
     symbolizer["size"] = size
     # We use SLD graphic-margin as top, right, bottom, left to mimic the combination of
     # ArcGIS stepX, stepY, offsetX, offsetY
     if symbolizer.get("maxX") and symbolizer.get("maxY"):
         # MaxX and MaxY are a custom property for shapes and already in px.
-        maxX = math.floor(symbolizer["maxX"] * POLYGON_FILL_RESIZE_FACTOR)
-        maxY = math.floor(symbolizer["maxY"] * POLYGON_FILL_RESIZE_FACTOR)
+        maxX = math.floor(symbolizer["maxX"] * resize_factor) or 1
+        maxY = math.floor(symbolizer["maxY"] * resize_factor) or 1
     else:
         maxX = size / 2
         maxY = size / 2

--- a/bridgestyle/arcgis/wkt_geometries.py
+++ b/bridgestyle/arcgis/wkt_geometries.py
@@ -1,5 +1,9 @@
 import math
 
+def height_normalized(coords: list[list[float]]) -> list[list[float]]:
+    height = max([coord[1] for coord in coords]) - min([coord[1] for coord in coords])
+    return [[coord[0] / height, coord[1] / height] for coord in coords]
+
 def distanceBetweenPoints(a: list, b: list) -> float:
     return math.sqrt((b[0]-a[0])**2 + (b[1]-a[1])**2)
 
@@ -8,6 +12,9 @@ def to_wkt(geometry: dict) -> dict:
 
     if geometry.get("rings"):
         rings = geometry["rings"][0]
+        # GeoServer will rescale the symbol using the specified size, using the height as a reference
+        # So we normalize the coordinates to have a height of 1
+        rings = height_normalized(rings)
         coordinates = ", ".join([" ".join([str(i) for i in j]) for j in rings])
         return {
                     "wellKnownName": f"wkt://POLYGON(({coordinates}))",


### PR DESCRIPTION
After the bug fixes in geotools regarding the polygon fills it seems our code was not working correctly anymore when using a custom polygon as marker (WKT). The polygon was way to big and a stroke was added even though there was none in the original lyrx.

This PR aims to improve this special case while limiting to a minimum the impact on other types of polygon marker fills