### PR TITLE
Fix whereClause (labels)

### DIFF
--- a/bridgestyle/arcgis/constants.py
+++ b/bridgestyle/arcgis/constants.py
@@ -1,18 +1,23 @@
+import re
 from enum import Enum
 
 
 ESRI_SYMBOLS_FONT = "ESRI Default Marker"
-PT_TO_PX_FACTOR = 4/3
-POLYGON_FILL_RESIZE_FACTOR = 2/3
-OFFSET_FACTOR = 4/3
+PT_TO_PX_FACTOR = 4 / 3
+POLYGON_FILL_RESIZE_FACTOR = 2 / 3
+OFFSET_FACTOR = 4 / 3
+PROPERTY_NAME_PATTERN = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
 
 class MarkerPlacementPosition(Enum):
     START = "startPoint"
     END = "endPoint"
 
+
 class MarkerPlacementAngle(Enum):
     START = "startAngle"
     END = "endAngle"
+
 
 def pt_to_px(pt):
     return pt * PT_TO_PX_FACTOR

--- a/bridgestyle/arcgis/togeostyler.py
+++ b/bridgestyle/arcgis/togeostyler.py
@@ -879,10 +879,11 @@ def _ptToPxProp(obj: dict, prop: str, defaultValue: Union[float, int], asFloat=T
     value = pt_to_px(float(obj.get(prop)))
     return value if asFloat else round(value)
 
+
 def processScaleDenominator(minimumScale, maximumScale):
     scaleDenominator = {}
-    if minimumScale is not None:
+    if isinstance(minimumScale, (int, float)):
         scaleDenominator["max"] = minimumScale
-    if maximumScale is not None:
+    if isinstance(maximumScale, (int, float)):
         scaleDenominator["min"] = maximumScale
     return scaleDenominator


### PR DESCRIPTION
The previous test for checking the validity of a property name (isalpha()) was too strict and would fail for instance if an underscore was present. It's replaced with a regex. Additionnally the convertWhereClause was removing all parentheses in the expression including those in the property value. This is now limited to the opening and closing parentheses at the beginining and at the end of the expression.

Additionnally there are cases in a lyrx where the maximum or minimum scale is NaN so we test that the value is numeric before adding it to the rule.

More info in [GSAAR-109](https://camptocamp.atlassian.net/browse/GSAAR-109)

[GSAAR-109]: https://camptocamp.atlassian.net/browse/GSAAR-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ