### PR TITLE
Restrict scale for all rules

### DIFF
--- a/bridgestyle/arcgis/togeostyler.py
+++ b/bridgestyle/arcgis/togeostyler.py
@@ -73,6 +73,13 @@ def processLayer(layer, options=None):
         if rotation:
             for rule in rules:
                 [symbolizer.update({"rotate": rotation}) for symbolizer in rule["symbolizers"]]
+        scaleDenominator = processScaleDenominator(
+            layer.get("minScale"), layer.get("maxScale")
+        )
+        if scaleDenominator is not {}:
+            for rule in rules:
+                if not rule.get("scaleDenominator"):
+                    rule["scaleDenominator"] = scaleDenominator
 
         geostyler["rules"] = rules
     elif layer["type"] == "CIMRasterLayer":


### PR DESCRIPTION
lyrx allows to restrict scale for the whole layer. Add the scale limit for each rule of the style in such cases, without overriding the scale limit at the rule level if there is one

[GSAAR-112](https://camptocamp.atlassian.net/browse/GSAAR-112)

[GSAAR-112]: https://camptocamp.atlassian.net/browse/GSAAR-112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ